### PR TITLE
Support for aliases on start command.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "symfony/config": "^2.7",
         "guzzlehttp/guzzle": "^6.1",
         "doctrine/cache": "^1.4",
-        "herrera-io/phar-update": "^2.0"
+        "herrera-io/phar-update": "^2.0",
+        "stecman/symfony-console-completion": "^0.6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5f024af105ea542a217ed8bdadebf8db",
+    "hash": "51e5f55e3c99b2e577c08ee47068aefc",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -974,6 +974,51 @@
                 "validator"
             ],
             "time": "2015-01-04 21:18:15"
+        },
+        {
+            "name": "stecman/symfony-console-completion",
+            "version": "0.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stecman/symfony-console-completion.git",
+                "reference": "0e426113086878a21aea9db0b2996d2f702b6d33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stecman/symfony-console-completion/zipball/0e426113086878a21aea9db0b2996d2f702b6d33",
+                "reference": "0e426113086878a21aea9db0b2996d2f702b6d33",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2",
+                "symfony/console": "~2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stecman\\Component\\Symfony\\Console\\BashCompletion\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Holdaway",
+                    "email": "stephen@stecman.co.nz"
+                }
+            ],
+            "description": "Automatic BASH completion for Symfony Console Component based applications.",
+            "time": "2015-08-30 15:37:24"
         },
         {
             "name": "symfony/config",

--- a/services.yml
+++ b/services.yml
@@ -130,3 +130,7 @@ services:
     arguments: ["@connector", "@repository"]
     tags:
       -  { name: command }
+  app.command.completion:
+    class: Stecman\Component\Symfony\Console\BashCompletion\CompletionCommand
+    tags:
+      -  { name: command }

--- a/src/Commands/Start.php
+++ b/src/Commands/Start.php
@@ -10,12 +10,14 @@ use Doctrine\DBAL\Driver\Connection;
 use Larowlan\Tl\Connector\Connector;
 use Larowlan\Tl\Formatter;
 use Larowlan\Tl\Repository\Repository;
+use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareInterface;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Start extends Command {
+class Start extends Command implements CompletionAwareInterface {
 
   /**
    * @var \Larowlan\Tl\Connector\Connector
@@ -82,6 +84,28 @@ class Start extends Command {
     else {
       $output->writeln('<error>Error: no such ticket id or access denied</error>');
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function completeOptionValues($optionName, CompletionContext $context) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function completeArgumentValues($argumentName, CompletionContext $context) {
+    $aliases = [];
+    if ($argumentName === 'issue_number') {
+      // Get all the aliases that are similar to our current search.
+      $results = $this->repository->listAliases($context->getWordAtIndex(2));
+      foreach ($results as $alias) {
+        $aliases[] = $alias->alias;
+      }
+    }
+    return $aliases;
   }
 
 }

--- a/src/Repository/DbRepository.php
+++ b/src/Repository/DbRepository.php
@@ -287,4 +287,17 @@ class DbRepository implements Repository {
       ->fetchColumn();
   }
 
+  public function listAliases($filter = '') {
+    $query = $this->qb()->select('alias')
+      ->from('aliases');
+    if (!empty($filter)) {
+      $query
+        ->where('alias LIKE :filter')
+        ->setParameter(':filter', $filter . '%');
+    }
+    return $query
+      ->execute()
+      ->fetchAll(\PDO::FETCH_OBJ);
+  }
+
 }

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -38,5 +38,5 @@ interface Repository {
   public function addAlias($ticket_id, $alias);
   public function removeAlias($ticket_id, $alias);
   public function loadAlias($alias);
-
+  public function listAliases($filter = '');
 }


### PR DESCRIPTION
Fixed #33 

To test this run the following, make sure to update the path to tl.php

```
source <(/Users/benjy/Sites/tl/bin/tl.php _completion --generate-hook)
```

Now type the full path, /Users/benjy/Sites/tl/bin/tl.php start [hit tab] and you should see your aliases autocomplete. Pretty neat, but we also get free command completion, eg, hit tab before you've finished typing "start"

Once we've deployed this, everyone will simply put this in their .zshrc/.bashrc file

```
source <(tl _completion --generate-hook)
```
