### PR TITLE
Using property assignment instead of addChild() escapes the value. Escape strings

### DIFF
--- a/src/Connector/RedmineConnector.php
+++ b/src/Connector/RedmineConnector.php
@@ -109,7 +109,6 @@ class RedmineConnector implements Connector {
     ];
     $xml = new \SimpleXMLElement('<?xml version="1.0"?><time_entry></time_entry>');
     foreach ($data as $key => $value) {
-      $xml->addChild($key, $value);
       $xml->$key = $value;
     }
     try {

--- a/src/Connector/RedmineConnector.php
+++ b/src/Connector/RedmineConnector.php
@@ -110,6 +110,7 @@ class RedmineConnector implements Connector {
     $xml = new \SimpleXMLElement('<?xml version="1.0"?><time_entry></time_entry>');
     foreach ($data as $key => $value) {
       $xml->addChild($key, $value);
+      $xml->$key = $value;
     }
     try {
       $response = $this->httpClient->request('POST', $url, [


### PR DESCRIPTION
Fixes #52
