### PR TITLE
Billable stats for month

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -113,6 +113,7 @@ services:
       arguments: ["@connector", "@repository", '%config%']
       tags:
         -  { name: command }
+        -  { name: configurable }
   app.command.status:
     class: Larowlan\Tl\Commands\Status
     arguments: ["@connector", "@repository"]

--- a/services.yml
+++ b/services.yml
@@ -110,7 +110,7 @@ services:
       -  { name: command }
   app.command.billable:
       class: Larowlan\Tl\Commands\Billable
-      arguments: ["@connector", "@repository"]
+      arguments: ["@connector", "@repository", '%config%']
       tags:
         -  { name: command }
   app.command.status:

--- a/src/Commands/Billable.php
+++ b/src/Commands/Billable.php
@@ -53,8 +53,8 @@ class Billable extends Command {
   public function __construct(Connector $connector, Repository $repository, array $config) {
     $this->connector = $connector;
     $this->repository = $repository;
-    $this->billablePercentage = $config['billable_percentage'];
-    $this->hoursPerDay = $config['hours_per_day'];
+    $this->billablePercentage = !empty($config['billable_percentage']) ? $config['billable_percentage'] : .8;
+    $this->hoursPerDay = !empty($config['hours_per_day']) ? $config['hours_per_day'] : 8;
     parent::__construct();
   }
 
@@ -256,7 +256,7 @@ class Billable extends Command {
 
   protected function getWeekdaysPassedThisMonth() {
     $days_passed = date('d');
-    $weekends_passed = $days_passed / 7;
+    $weekends_passed = round($days_passed / 7);
     $days_passed -= ($weekends_passed * 2);
 
     // Don't include the current day before 3pm?

--- a/src/Commands/Configure.php
+++ b/src/Commands/Configure.php
@@ -7,11 +7,9 @@
 namespace Larowlan\Tl\Commands;
 
 use Larowlan\Tl\Configuration\ConfigurableService;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Yaml\Yaml;
 

--- a/src/Configuration/ConfigurableService.php
+++ b/src/Configuration/ConfigurableService.php
@@ -6,7 +6,7 @@
 
 namespace Larowlan\Tl\Configuration;
 
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -19,9 +19,9 @@ interface ConfigurableService {
   /**
    * Gets configuration for the service.
    *
-   * @param \Symfony\Component\Config\Definition\Builder\TreeBuilder $tree_builder
+   * @param \Symfony\Component\Config\Definition\Builder\NodeDefinition $root_node
    */
-  public static function getConfiguration(TreeBuilder $tree_builder);
+  public static function getConfiguration(NodeDefinition $root_node);
 
   public static function askPreBootQuestions(QuestionHelper $helper, InputInterface $input, OutputInterface $output, array $config);
 

--- a/src/Configuration/LoggerConfiguration.php
+++ b/src/Configuration/LoggerConfiguration.php
@@ -23,8 +23,9 @@ class LoggerConfiguration implements ConfigurationInterface, ConfigurationCollec
    */
   public function getConfigTreeBuilder() {
     $tree = new TreeBuilder();
+    $root = $tree->root('tl');
     foreach ($this->services as $service) {
-      $service::getConfiguration($tree);
+      $service::getConfiguration($root);
     }
     return $tree;
   }

--- a/src/Connector/RedmineConnector.php
+++ b/src/Connector/RedmineConnector.php
@@ -333,12 +333,6 @@ class RedmineConnector implements Connector, ConfigurableService {
         ->defaultValue('https://redmine.previousnext.com.au')
         ->isRequired()
         ->end()
-        ->scalarNode('billable_percentage')
-        ->defaultValue(0.8)
-        ->end()
-        ->scalarNode('hours_per_day')
-        ->defaultValue(8)
-        ->end()
       ->end();
   }
 

--- a/src/Connector/RedmineConnector.php
+++ b/src/Connector/RedmineConnector.php
@@ -333,6 +333,12 @@ class RedmineConnector implements Connector, ConfigurableService {
         ->defaultValue('https://redmine.previousnext.com.au')
         ->isRequired()
         ->end()
+        ->scalarNode('billable_percentage')
+        ->defaultValue(0.8)
+        ->end()
+        ->scalarNode('hours_per_day')
+        ->defaultValue(8)
+        ->end()
       ->end();
   }
 

--- a/src/Connector/RedmineConnector.php
+++ b/src/Connector/RedmineConnector.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
 use Larowlan\Tl\Configuration\ConfigurableService;
 use Larowlan\Tl\Ticket;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -313,13 +314,10 @@ class RedmineConnector implements Connector, ConfigurableService {
   }
 
   /**
-   * Gets configuration for the service.
-   *
-   * @param \Symfony\Component\Config\Definition\Builder\TreeBuilder $tree_builder
+   * {@inheritdoc}
    */
-  public static function getConfiguration(TreeBuilder $tree_builder) {
-    $root = $tree_builder->root('redmine');
-    $root->children()
+  public static function getConfiguration(NodeDefinition $root_node) {
+    $root_node->children()
         ->arrayNode('non_billable_projects')
         ->requiresAtLeastOneElement()
           ->prototype('scalar')


### PR DESCRIPTION
Feature request, shows percentage of the way through the month, and then you can compare that to how far through your billable hours and total hours you are. Lets you see how you're tracking for the month as a whole, not just based on the current time logged.

![screen shot 2016-11-21 at 7 20 12 am](https://cloud.githubusercontent.com/assets/863137/20467111/21a1010c-afbb-11e6-9d29-2bb7e3aa5431.png)
