### PR TITLE
Fixed a NaN warning in Billable.php.

### DIFF
--- a/src/Commands/Billable.php
+++ b/src/Commands/Billable.php
@@ -167,7 +167,7 @@ class Billable extends Command implements ConfigurableService {
     }
     $total = $billable + $non_billable + $unknown;
     $tag = 'info';
-    if ($billable / $total < $this->billablePercentage) {
+    if (($total == 0) || ($billable / $total < $this->billablePercentage)) {
       $tag = 'error';
     }
     if ($project) {


### PR DESCRIPTION
```PHP Warning:  Division by zero in phar:///usr/local/bin/tl/src/Commands/Billable.php on line 170
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/tl:0
PHP   2. require() /usr/local/bin/tl:10
PHP   3. Symfony\Component\Console\Application->run() phar:///usr/local/bin/tl/bin/tl.php:22
PHP   4. Larowlan\Tl\Application->doRun() phar:///usr/local/bin/tl/vendor/symfony/console/Application.php:126
PHP   5. Symfony\Component\Console\Application->doRun() phar:///usr/local/bin/tl/src/Application.php:111
PHP   6. Symfony\Component\Console\Application->doRunCommand() phar:///usr/local/bin/tl/vendor/symfony/console/Application.php:195
PHP   7. Symfony\Component\Console\Command\Command->run() phar:///usr/local/bin/tl/vendor/symfony/console/Application.php:878
PHP   8. Larowlan\Tl\Commands\Billable->execute() phar:///usr/local/bin/tl/vendor/symfony/console/Command/Command.php:259```