### PR TITLE
Add time entry comment to interactive tag question if available

### DIFF
--- a/src/Commands/Tag.php
+++ b/src/Commands/Tag.php
@@ -90,12 +90,13 @@ class Tag extends Command {
       }
       $title = $this->connector->ticketDetails($entry->tid);
       $question = new ChoiceQuestion(
-        sprintf('Enter tag for slot <comment>%d</comment> [<info>%d</info>]: %s [<info>%s h</info>] [%s]',
+        sprintf('Enter tag for slot <comment>%d</comment> [<info>%d</info>]: %s [<info>%s h</info>] [%s] %s',
           $entry->id,
           $entry->tid,
           $title->getTitle(),
           $entry->duration,
-          $last ?: static::DEFAULT_TAG
+          $last ?: static::DEFAULT_TAG,
+          $entry->comment ? '- "' . $entry->comment . '"': ''
         ),
         $categories,
         $last ?: static::DEFAULT_TAG
@@ -129,12 +130,13 @@ class Tag extends Command {
         return;
       }
       $question = new ChoiceQuestion(
-        sprintf('Enter tag for slot <comment>%d</comment> [<info>%d</info>]: %s [<info>%s h</info>] [%s]',
+        sprintf('Enter tag for slot <comment>%d</comment> [<info>%d</info>]: %s [<info>%s h</info>] [%s] %s',
           $entry->id,
           $entry->tid,
           $title->getTitle(),
           Formatter::formatDuration($entry->end - $entry->start),
-          static::DEFAULT_TAG
+          static::DEFAULT_TAG,
+          $entry->comment ? '- "' . $entry->comment . '"': ''
         ),
         $categories,
         static::DEFAULT_TAG


### PR DESCRIPTION
When interactively tagging multiple time entries at once using `tl tag` it can be sometimes be hard to remember which tag is best for your particular time entry, especially if you have multiple time entries for the same redmine ticket that require different tags.

This makes it easier to remember what you are tagging if you don't tag your entries one by one after you start them, but add a comment, something like `tl start xyz "my comment"`.

Output before this PR when interactively tagging with `tl tag`:
`Enter tag for slot 1234 [5678]: The ticket name [0.25 h] [DefaultTag:9]`

Output after:
`Enter tag for slot 1234 [5678]: The ticket name [0.25 h] [DefaultTag:9] - "my comment"`