### PR TITLE
Added support for more duration types.

### DIFF
--- a/src/Commands/Edit.php
+++ b/src/Commands/Edit.php
@@ -3,6 +3,7 @@
 namespace Larowlan\Tl\Commands;
 
 use Larowlan\Tl\Connector\Connector;
+use Larowlan\Tl\Formatter;
 use Larowlan\Tl\Input;
 use Larowlan\Tl\Repository\Repository;
 use Symfony\Component\Console\Command\Command;
@@ -72,8 +73,10 @@ class Edit extends Command implements LogAwareCommand {
       $output->writeln('<error>You cannot edit a slot that has been sent to the backend</error>');
       return 1;
     }
+
     $this->repository->edit($slot_id, $seconds);
-    $output->writeln(sprintf('Updated slot %s to <info>%sh</info>', $slot_id, round($seconds / 3600, 5)));
+    $output->writeln(sprintf('Updated slot %s to <info>%s</info>', $slot_id, Formatter::formatDuration($seconds)));
+    return 0;
   }
 
 }

--- a/src/Commands/Edit.php
+++ b/src/Commands/Edit.php
@@ -3,6 +3,7 @@
 namespace Larowlan\Tl\Commands;
 
 use Larowlan\Tl\Connector\Connector;
+use Larowlan\Tl\Input;
 use Larowlan\Tl\Repository\Repository;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -39,10 +40,10 @@ class Edit extends Command implements LogAwareCommand {
   protected function configure() {
     $this
       ->setName('edit')
-      ->setDescription('Edits a time entry')
+      ->setDescription('Edits a time entry. Start time is modified to be duration-ago')
       ->setHelp('Edits a time entry. <comment>Usage:</comment> <info>tl edit [slot ID] [duration in hours]</info>')
       ->addArgument('slot_id', InputArgument::REQUIRED, 'Slot ID to edit')
-      ->addArgument('duration', InputArgument::REQUIRED, 'Duration in hours to change slot to');
+      ->addArgument('duration', InputArgument::REQUIRED, 'A duration. For example, 15 minutes: 15m or .25 :15. Mixed granularity is also available, for example: 15s, 15m, 1.5h, 1d.');
   }
 
   /**
@@ -51,13 +52,28 @@ class Edit extends Command implements LogAwareCommand {
   protected function execute(InputInterface $input, OutputInterface $output) {
     $slot_id = $input->getArgument('slot_id');
     $duration = $input->getArgument('duration');
+
+    try {
+      $seconds = Input::parseInterval($duration);
+    }
+    catch (\Throwable $e) {
+      $output->writeln('<error>' . $e->getMessage() . '</error>');
+      return 1;
+    }
+
     $slot = $this->repository->slot($slot_id);
+    if ($slot === FALSE) {
+      $output->writeln('<error>Slot does not exist.</error>');
+      return 1;
+    }
+
+
     if (isset($slot->teid)) {
       $output->writeln('<error>You cannot edit a slot that has been sent to the backend</error>');
       return 1;
     }
-    $this->repository->edit($slot_id, $duration);
-    $output->writeln(sprintf('Updated slot %s to <info>%s h</info>', $slot_id, $duration));
+    $this->repository->edit($slot_id, $seconds);
+    $output->writeln(sprintf('Updated slot %s to <info>%sh</info>', $slot_id, round($seconds / 3600, 5)));
   }
 
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -11,7 +11,7 @@ class Formatter {
    * Formats a duration.
    *
    * @param int $duration
-   *   Duration.
+   *   Duration in seconds.
    *
    * @return string
    *   Formatted duration.

--- a/src/Input.php
+++ b/src/Input.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Larowlan\Tl;
+
+/**
+ * Input utility.
+ *
+ * Parses user input into PHP data types.
+ */
+class Input {
+
+  /**
+   * Parses a user supplied interval.
+   *
+   * @param string $rawInterval
+   *   An interval.
+   *
+   * @return int
+   *   Interval in seconds.
+   *
+   * @throws \InvalidArgumentException
+   *   When user input could not be parsed.
+   */
+  public static function parseInterval(string $rawInterval) {
+    $intervals = explode(' ', trim($rawInterval));
+
+    $total = 0;
+    foreach ($intervals as $interval) {
+      $interval = trim($interval);
+      if (empty($interval)) {
+        continue;
+      }
+
+      $firstChar = substr($interval, 0, 1);
+
+      // Minutes.
+      if ($firstChar === ':') {
+        preg_match('/^\:(?<minute>\d{1,5})$/', $interval, $matches);
+        if (!isset($matches['minute'])) {
+          throw new \InvalidArgumentException('Could not parse minutes.');
+        }
+        $minute = $matches['minute'];
+
+        // Pad single character. Single digit minutes should be prefixed with a
+        // zero.
+        if (strlen($minute) === 1) {
+          // For example :5 === 50 minutes.
+          $minute .= '0';
+        }
+
+        $total += ($minute * 60);
+
+        continue;
+      }
+
+      // Fractions of an hour.
+      elseif (preg_match('/^\d{0,10}\.\d{1,10}$/', $interval, $matches)) {
+        $total += (int) round((float) ($matches[0]) * 3600);
+        continue;
+      }
+
+      // Short durations. E.g 10s, 1m, 1h, and concatenations 1h30m, '1h 30m'.
+      // First, check without capture groups, in case user added extra junk
+      // before or after.
+      elseif (preg_match('/^(\d{1,10}[smhd])+$/', $interval)) {
+        // Re-match with capture groups.
+        preg_match_all('/(?<num>\d{1,10})(?<suffix>[smhd])+/U', $interval, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+          $number = (int) $match['num'];
+          switch ($match['suffix']) {
+            case 's':
+              $total += $number;
+              break;
+
+            case 'm':
+              $total += $number * 60;
+              break;
+
+            case 'h':
+              $total += $number * 3600;
+              break;
+
+            case 'd':
+              $total += $number * 86400;
+              break;
+
+          }
+        }
+
+        continue;
+      }
+
+      throw new \InvalidArgumentException('Unable to parse interval.');
+    }
+
+    return $total;
+  }
+
+}

--- a/src/Repository/DbRepository.php
+++ b/src/Repository/DbRepository.php
@@ -223,10 +223,10 @@ class DbRepository implements Repository {
   /**
    * {@inheritdoc}
    */
-  public function edit($slot_id, $duration) {
+  public function edit($slot_id, int $duration) {
     $request_time = $this::requestTime();
     return $this->qb()->update('slots')
-      ->set('start', $request_time - ($duration * 3600))
+      ->set('start', $request_time - $duration)
       ->set('end', $request_time)
       ->where('id = :id')
       ->setParameter(':id', $slot_id)->execute();

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -27,7 +27,7 @@ interface Repository {
 
   public function store($entries);
 
-  public function edit($slot_id, $duration);
+  public function edit($slot_id, int $duration);
 
   public function tag($tag_id, $slot_id = NULL);
 

--- a/tests/InputUtilityTest.php
+++ b/tests/InputUtilityTest.php
@@ -71,13 +71,11 @@ class InputUtilityTest extends TlTestBase {
     $data['friendly - simple seconds'] = ['40s', 40];
     $data['friendly - simple minutes'] = ['40m', 40 * 60];
     $data['friendly - simple hours'] = ['40h', 40 * 3600];
-    $data['friendly - simple days'] = ['40d', 40 * 3600 * 24];
     $data['friendly - hundreds minutes'] = ['400m', 400 * 60];
     $data['friendly - multiple concat'] = ['40s1m', 100];
     $data['friendly - whitespace'] = ['40s 1m', 100];
     $data['friendly - whitespace and concat'] = ['40s 1m 1s1s', 102];
-    // 3600 + 172800 + 7200 + 3600 + 60 + 40.
-    $data['friendly - disorderly multiple'] = ['1h2d2h1h1m40s', 187300];
+    $data['friendly - disorderly multiple'] = ['1h2h1h1m40s', 3600 + 7200 + 3600 + 60 + 40];
     $data['friendly - junk on side'] = ['ak40s1ma', NULL, 'Unable to parse interval.'];
 
     // Other

--- a/tests/InputUtilityTest.php
+++ b/tests/InputUtilityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Larowlan\Tl\Tests\Commands;
+
+use Larowlan\Tl\Input;
+use Larowlan\Tl\Tests\TlTestBase;
+
+/**
+ * Tests input utility class.
+ *
+ * @coversDefaultClass \Larowlan\Tl\Input
+ */
+class InputUtilityTest extends TlTestBase {
+
+  /**
+   * @covers ::parseInterval
+   *
+   * @dataProvider providerTestInterval
+   */
+  public function testInterval($string, ?string $assertValue, ?string $exceptionMessage = NULL): void {
+    if (!isset($assertValue)) {
+      $this->expectException(\InvalidArgumentException::class);
+      $this->expectExceptionMessage($exceptionMessage);
+    }
+
+    $return = Input::parseInterval($string);
+
+    if (isset($assertValue)) {
+      $this->assertEquals($assertValue, $return);
+    }
+  }
+
+  /**
+   * Data for testing.
+   *
+   * @see ::testInterval
+   */
+  public function providerTestInterval(): array {
+    $data = [];
+
+    // Invalid.
+    $data['invalid junk around'] = ['daslkdjhagsjd', NULL, 'Unable to parse interval.'];
+    $data['invalid numbers'] = ['d4124haj', NULL, 'Unable to parse interval.'];
+    $data['invalid numbers spaces'] = ['d41 24haj', NULL, 'Unable to parse interval.'];
+
+    // Input coercion.
+    $data['whitespace before'] = [' :15', 900];
+    $data['whitespace after'] = [':15 ', 900];
+    $data['whitespace around'] = [' :15 ', 900];
+    $data['whitespace between'] = [' :10  :20 ', 1800];
+    $data['whitespace junk between'] = [' :10 blah  :20 ', NULL, 'Unable to parse interval.'];
+
+    // Test minutes.
+    $data['minutes - shortened'] = [':3', 1800];
+    $data['minutes - minute'] = [':05', 300];
+    $data['minutes - double'] = [':15', 900];
+    $data['minutes - long'] = [':100', 6000];
+    $data['minutes - suffix junk'] = [':100m', NULL, 'Could not parse minutes.'];
+
+    // Test fractions.
+    $data['fraction - double digit'] = ['.25', 900];
+    $data['fraction - single digit'] = ['.5', 1800];
+    $data['fraction - multi hour'] = ['1.5', 5400];
+    $data['fraction - rounded'] = ['.55', 1980];
+    $data['fraction - long'] = ['.75555', 2720];
+    $data['fraction - suffix junk'] = ['.55m', NULL, 'Unable to parse interval.'];
+
+    // Friendly durations.
+    $data['friendly - simple seconds'] = ['40s', 40];
+    $data['friendly - simple minutes'] = ['40m', 40 * 60];
+    $data['friendly - simple hours'] = ['40h', 40 * 3600];
+    $data['friendly - simple days'] = ['40d', 40 * 3600 * 24];
+    $data['friendly - hundreds minutes'] = ['400m', 400 * 60];
+    $data['friendly - multiple concat'] = ['40s1m', 100];
+    $data['friendly - whitespace'] = ['40s 1m', 100];
+    $data['friendly - whitespace and concat'] = ['40s 1m 1s1s', 102];
+    // 3600 + 172800 + 7200 + 3600 + 60 + 40.
+    $data['friendly - disorderly multiple'] = ['1h2d2h1h1m40s', 187300];
+    $data['friendly - junk on side'] = ['ak40s1ma', NULL, 'Unable to parse interval.'];
+
+    // Other
+    $data['combination'] = ['900s :15 .25', 2700];
+
+    return $data;
+  }
+
+}


### PR DESCRIPTION
Added support for alternative intervals for edit command.

For example you can use:

Fraction of hour (Redmine style): 

* 15 minutes: `tl edit FOO .25`
* 1hour 15 minutes: `tl edit FOO 1.25`

Minutes: 

* 30 minutes: `tl edit FOO :30`
* 1 hour 30 minutes: `tl edit FOO 1:30`

Friendly intervals:

* 1 hour 30 minutes: `tl edit FOO 1h30m`
* 1 hour 30 minutes: `tl edit FOO '1h 30m'`
* 15 minutes: `tl edit FOO 900s`
* 1 day: `tl edit FOO 1d`

Also fixed edit command accepting invalid slot IDs without error.
