### PR TITLE
Alias command enhancements

### DIFF
--- a/src/Commands/Alias.php
+++ b/src/Commands/Alias.php
@@ -80,6 +80,26 @@ class Alias extends Command {
   }
 
   /**
+   * Validates an alias name.
+   *
+   * Alias names may only contain letters, digits, underscores, hyphens, and
+   * fullstops. Commas and spaces are excluded because commas are used as the multiselect
+   * separator in interactive choice lists.
+   *
+   * @param string $alias
+   *   The alias name to validate.
+   *
+   * @return string|null
+   *   NULL if valid, or an error message string if invalid.
+   */
+  protected function validateAliasName(string $alias): ?string {
+    if (!preg_match('/^[a-zA-Z0-9_\-\.]+$/', $alias)) {
+      return 'Alias names may only contain letters, digits, underscores, hyphens, and fullstops.';
+    }
+    return NULL;
+  }
+
+  /**
    * Lists all aliases.
    */
   protected function listAliases(OutputInterface $output): int {
@@ -121,6 +141,7 @@ class Alias extends Command {
 
     // Interactive add loop.
     $helper = $this->getHelper('question');
+    $another = TRUE;
     do {
       $tidQuestion = new Question('Ticket ID: ');
       $newTid = $helper->ask($input, $output, $tidQuestion);
@@ -133,6 +154,10 @@ class Alias extends Command {
       $newAlias = $helper->ask($input, $output, $aliasQuestion);
       if (!$newAlias) {
         $output->writeln('<error>Alias cannot be empty</error>');
+        continue;
+      }
+      if ($error = $this->validateAliasName($newAlias)) {
+        $output->writeln(sprintf('<error>%s</error>', $error));
         continue;
       }
 
@@ -150,6 +175,10 @@ class Alias extends Command {
    * @return bool TRUE on success, FALSE on failure.
    */
   protected function doAddAlias($tid, string $alias, InputInterface $input, OutputInterface $output): bool {
+    if ($error = $this->validateAliasName($alias)) {
+      $output->writeln(sprintf('<error>%s</error>', $error));
+      return FALSE;
+    }
     $existing = $this->repository->findAlias($alias);
     if ($existing) {
       $helper = $this->getHelper('question');
@@ -250,8 +279,8 @@ class Alias extends Command {
       return 0;
     }
 
+    $this->repository->removeNamedAliases($toDelete);
     foreach ($toDelete as $aliasName) {
-      $this->repository->removeAliasByName($aliasName);
       $output->writeln(sprintf('Removed alias <comment>%s</comment>', $aliasName));
     }
 
@@ -298,6 +327,12 @@ class Alias extends Command {
 
     // Prompt for new alias name and ticket ID, pre-filled with current values.
     $newAliasQuestion = new Question(sprintf('Alias [<comment>%s</comment>]: ', $existing->alias), $existing->alias);
+    $newAliasQuestion->setValidator(function ($value) {
+      if ($error = $this->validateAliasName((string) $value)) {
+        throw new \InvalidArgumentException($error);
+      }
+      return $value;
+    });
     $newAlias = $helper->ask($input, $output, $newAliasQuestion);
 
     $newTidQuestion = new Question(sprintf('Ticket ID [<comment>%s</comment>]: ', $existing->tid), (string) $existing->tid);

--- a/src/Commands/Alias.php
+++ b/src/Commands/Alias.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
 
 /**
  *
@@ -41,15 +44,20 @@ class Alias extends Command {
   protected function configure() {
     $this
       ->setName('alias')
-      ->setDescription('Creates an alias')
-      ->setHelp('Creates an alias')
-      ->addOption('delete', NULL, InputOption::VALUE_NONE, 'Delete the given combination')
+      ->setDescription('Manages aliases')
+      ->setHelp('Manages ticket aliases')
+      ->addOption('delete', NULL, InputOption::VALUE_NONE, 'Delete alias(es)')
       ->addOption('list', NULL, InputOption::VALUE_NONE, 'List aliases')
+      ->addOption('edit', NULL, InputOption::VALUE_NONE, 'Edit an alias')
       ->addArgument('ticket_id', InputArgument::OPTIONAL, 'Ticket ID to add an alias for')
       ->addArgument('alias', InputArgument::OPTIONAL, 'Alias to use')
+      ->addUsage('tl alias')
       ->addUsage('tl alias 12345 "foobar"')
       ->addUsage('tl alias --list')
-      ->addUsage('tl alias 12345 "foobar" --delete');
+      ->addUsage('tl alias --delete')
+      ->addUsage('tl alias "foobar" --delete')
+      ->addUsage('tl alias --edit')
+      ->addUsage('tl alias "foobar" --edit');
   }
 
   /**
@@ -57,49 +65,268 @@ class Alias extends Command {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     if ($input->getOption('list')) {
-      $table = new Table($output);
-      $table->setHeaders(['Alias', 'Issue number']);
-      $list = $this->repository->listAliases();
-      $rows = [];
-      foreach ($list as $alias) {
-        $rows[] = [
-          $alias->alias,
-          $alias->tid,
-        ];
-      }
-      $table->setRows($rows);
-      $table->render();
-      return 0;
+      return $this->listAliases($output);
     }
+
+    if ($input->getOption('delete')) {
+      return $this->deleteAliases($input, $output);
+    }
+
+    if ($input->getOption('edit')) {
+      return $this->editAlias($input, $output);
+    }
+
+    return $this->addAliases($input, $output);
+  }
+
+  /**
+   * Lists all aliases.
+   */
+  protected function listAliases(OutputInterface $output): int {
+    $table = new Table($output);
+    $table->setHeaders(['Alias', 'Issue number']);
+    $rows = [];
+    foreach ($this->repository->listAliases() as $alias) {
+      $rows[] = [$alias->alias, $alias->tid];
+    }
+    $table->setRows($rows);
+    $table->render();
+    return 0;
+  }
+
+  /**
+   * Adds one or more aliases.
+   *
+   * If both positional args are provided, adds a single alias non-interactively.
+   * Otherwise, enters an interactive loop.
+   */
+  protected function addAliases(InputInterface $input, OutputInterface $output): int {
     $alias = $input->getArgument('alias');
     $tid = $input->getArgument('ticket_id');
-    if ($input->getOption('delete')) {
-      if ($this->repository->removeAlias($tid, $alias)) {
-        $output->writeln('Removed alias');
+
+    // One-shot non-interactive add (both args provided).
+    if ($alias && $tid) {
+      return $this->doAddAlias($tid, $alias, $input, $output) ? 0 : 1;
+    }
+
+    // Validation errors for partial args (matches old behaviour).
+    if ($tid && !$alias) {
+      $output->writeln('<error>Missing alias</error>');
+      return 1;
+    }
+    if ($alias && !$tid) {
+      $output->writeln('<error>Missing ticket number</error>');
+      return 1;
+    }
+
+    // Interactive add loop.
+    $helper = $this->getHelper('question');
+    do {
+      $tidQuestion = new Question('Ticket ID: ');
+      $newTid = $helper->ask($input, $output, $tidQuestion);
+      if (!$newTid) {
+        $output->writeln('<error>Ticket ID cannot be empty</error>');
+        continue;
       }
-      else {
-        $output->writeln('<error>Unable to delete alias</error>');
+
+      $aliasQuestion = new Question('Alias: ');
+      $newAlias = $helper->ask($input, $output, $aliasQuestion);
+      if (!$newAlias) {
+        $output->writeln('<error>Alias cannot be empty</error>');
+        continue;
+      }
+
+      $this->doAddAlias($newTid, $newAlias, $input, $output);
+
+      $another = $helper->ask($input, $output, new ConfirmationQuestion('Add another? (y/N): ', FALSE));
+    } while ($another);
+
+    return 0;
+  }
+
+  /**
+   * Performs the actual add, handling duplicate checking.
+   *
+   * @return bool TRUE on success, FALSE on failure.
+   */
+  protected function doAddAlias($tid, string $alias, InputInterface $input, OutputInterface $output): bool {
+    $existing = $this->repository->findAlias($alias);
+    if ($existing) {
+      $helper = $this->getHelper('question');
+      $confirm = $helper->ask($input, $output, new ConfirmationQuestion(
+        sprintf('Alias <comment>%s</comment> already points to ticket <comment>%s</comment>. Update to <comment>%s</comment>? (y/N): ', $alias, $existing->tid, $tid),
+        FALSE
+      ));
+      if (!$confirm) {
+        $output->writeln('Skipped.');
+        return TRUE;
+      }
+      $this->repository->updateAlias($alias, $alias, $tid);
+      $output->writeln(sprintf('Updated alias <comment>%s</comment> -> <comment>%s</comment>', $alias, $tid));
+      return TRUE;
+    }
+
+    if ($this->repository->addAlias($tid, $alias)) {
+      $output->writeln(sprintf('Created new alias <comment>%s</comment> -> <comment>%s</comment>', $alias, $tid));
+      return TRUE;
+    }
+
+    $output->writeln('<error>Unable to create alias</error>');
+    return FALSE;
+  }
+
+  /**
+   * Deletes aliases.
+   *
+   * If an alias positional arg is provided, deletes that specific alias after
+   * confirmation. Otherwise, shows an interactive multi-select list.
+   */
+  protected function deleteAliases(InputInterface $input, OutputInterface $output): int {
+    $helper = $this->getHelper('question');
+    $aliasArg = $input->getArgument('alias') ?? $input->getArgument('ticket_id');
+
+    // Single alias delete by name.
+    if ($aliasArg) {
+      $existing = $this->repository->findAlias($aliasArg);
+      if (!$existing) {
+        $output->writeln(sprintf('<error>Alias <comment>%s</comment> not found</error>', $aliasArg));
+        return 1;
+      }
+      $confirm = $helper->ask($input, $output, new ConfirmationQuestion(
+        sprintf('Delete alias <comment>%s</comment> -> <comment>%s</comment>? (y/N): ', $existing->alias, $existing->tid),
+        FALSE
+      ));
+      if (!$confirm) {
+        $output->writeln('Cancelled.');
+        return 0;
+      }
+      $this->repository->removeAliasByName($aliasArg);
+      $output->writeln(sprintf('Removed alias <comment>%s</comment>', $aliasArg));
+      return 0;
+    }
+
+    // Interactive multi-select delete.
+    $list = $this->repository->listAliases();
+    if (empty($list)) {
+      $output->writeln('No aliases found.');
+      return 0;
+    }
+
+    $choices = [];
+    foreach ($list as $row) {
+      $choices[] = sprintf('%s -> %s', $row->alias, $row->tid);
+    }
+
+    $question = new ChoiceQuestion(
+      'Select aliases to delete (comma-separated numbers, or press Enter to cancel):',
+      $choices
+    );
+    $question->setMultiselect(TRUE);
+    $question->setErrorMessage('Invalid selection: %s');
+
+    $selected = $helper->ask($input, $output, $question);
+    if (empty($selected)) {
+      $output->writeln('Nothing selected.');
+      return 0;
+    }
+
+    // Parse alias names back out of the "alias -> tid" strings.
+    $toDelete = [];
+    foreach ($selected as $choice) {
+      [$aliasName] = explode(' -> ', $choice, 2);
+      $toDelete[] = $aliasName;
+    }
+
+    $output->writeln('The following aliases will be deleted:');
+    foreach ($selected as $choice) {
+      $output->writeln('  ' . $choice);
+    }
+    $confirm = $helper->ask($input, $output, new ConfirmationQuestion(
+      sprintf('Delete %d alias(es)? (y/N): ', count($toDelete)),
+      FALSE
+    ));
+    if (!$confirm) {
+      $output->writeln('Cancelled.');
+      return 0;
+    }
+
+    foreach ($toDelete as $aliasName) {
+      $this->repository->removeAliasByName($aliasName);
+      $output->writeln(sprintf('Removed alias <comment>%s</comment>', $aliasName));
+    }
+
+    return 0;
+  }
+
+  /**
+   * Edits an alias.
+   *
+   * If an alias positional arg is provided, edits that alias directly.
+   * Otherwise, shows an interactive picker first.
+   */
+  protected function editAlias(InputInterface $input, OutputInterface $output): int {
+    $helper = $this->getHelper('question');
+    $aliasArg = $input->getArgument('alias') ?? $input->getArgument('ticket_id');
+
+    if ($aliasArg) {
+      $existing = $this->repository->findAlias($aliasArg);
+      if (!$existing) {
+        $output->writeln(sprintf('<error>Alias <comment>%s</comment> not found</error>', $aliasArg));
         return 1;
       }
     }
     else {
-      if (!$alias) {
-        $output->writeln('<error>Missing alias</error>');
-        return 1;
+      // Interactive picker.
+      $list = $this->repository->listAliases();
+      if (empty($list)) {
+        $output->writeln('No aliases found.');
+        return 0;
       }
-      if (!$tid) {
-        $output->writeln('<error>Missing ticket number</error>');
-        return 1;
+
+      $choices = [];
+      foreach ($list as $row) {
+        $choices[] = sprintf('%s -> %s', $row->alias, $row->tid);
       }
-      if ($this->repository->addAlias($tid, $alias)) {
-        $output->writeln('Created new alias');
-      }
-      else {
-        $output->writeln('<error>Unable to create alias</error>');
-        return 1;
+
+      $question = new ChoiceQuestion('Select alias to edit:', $choices);
+      $question->setErrorMessage('Invalid selection: %s');
+      $selected = $helper->ask($input, $output, $question);
+
+      [$aliasName] = explode(' -> ', $selected, 2);
+      $existing = $this->repository->findAlias($aliasName);
+    }
+
+    // Prompt for new alias name and ticket ID, pre-filled with current values.
+    $newAliasQuestion = new Question(sprintf('Alias [<comment>%s</comment>]: ', $existing->alias), $existing->alias);
+    $newAlias = $helper->ask($input, $output, $newAliasQuestion);
+
+    $newTidQuestion = new Question(sprintf('Ticket ID [<comment>%s</comment>]: ', $existing->tid), (string) $existing->tid);
+    $newTid = $helper->ask($input, $output, $newTidQuestion);
+
+    if ($newAlias === $existing->alias && (string) $newTid === (string) $existing->tid) {
+      $output->writeln('No changes made.');
+      return 0;
+    }
+
+    // Check for collision if alias name is changing.
+    if ($newAlias !== $existing->alias) {
+      $collision = $this->repository->findAlias($newAlias);
+      if ($collision) {
+        $confirm = $helper->ask($input, $output, new ConfirmationQuestion(
+          sprintf('Alias <comment>%s</comment> already points to ticket <comment>%s</comment>. Overwrite? (y/N): ', $newAlias, $collision->tid),
+          FALSE
+        ));
+        if (!$confirm) {
+          $output->writeln('Cancelled.');
+          return 0;
+        }
+        // Remove the colliding alias first.
+        $this->repository->removeAliasByName($newAlias);
       }
     }
 
+    $this->repository->updateAlias($existing->alias, $newAlias, $newTid);
+    $output->writeln(sprintf('Updated alias <comment>%s</comment> -> <comment>%s</comment>', $newAlias, $newTid));
     return 0;
   }
 

--- a/src/Repository/DbRepository.php
+++ b/src/Repository/DbRepository.php
@@ -402,6 +402,47 @@ class DbRepository implements Repository {
   /**
    * {@inheritdoc}
    */
+  public function removeAliasByName(string $alias): int {
+    return (int) $this->qb()->delete('aliases')
+      ->where('alias = :alias')
+      ->setParameter(':alias', $alias)
+      ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function findAlias(string $alias): ?object {
+    $row = $this->qb()->select('alias', 'tid')
+      ->from('aliases')
+      ->where('alias = :alias')
+      ->setParameter(':alias', $alias)
+      ->execute()
+      ->fetch(\PDO::FETCH_OBJ);
+    return $row ?: NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function updateAlias(string $oldAlias, string $newAlias, $ticketId): void {
+    $this->qb()->delete('aliases')
+      ->where('alias = :alias')
+      ->setParameter(':alias', $oldAlias)
+      ->execute();
+    $this->qb()->insert('aliases')
+      ->values([
+        'tid' => ':ticket_id',
+        'alias' => ':alias',
+      ])
+      ->setParameter(':ticket_id', $ticketId)
+      ->setParameter(':alias', $newAlias)
+      ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function loadAlias($alias) {
     return $this->qb()->select('tid')
       ->from('aliases')

--- a/src/Repository/DbRepository.php
+++ b/src/Repository/DbRepository.php
@@ -426,18 +426,31 @@ class DbRepository implements Repository {
    * {@inheritdoc}
    */
   public function updateAlias(string $oldAlias, string $newAlias, $ticketId): void {
-    $this->qb()->delete('aliases')
-      ->where('alias = :alias')
-      ->setParameter(':alias', $oldAlias)
-      ->execute();
-    $this->qb()->insert('aliases')
-      ->values([
-        'tid' => ':ticket_id',
-        'alias' => ':alias',
-      ])
+    $this->qb()->update('aliases')
+      ->set('alias', ':new_alias')
+      ->set('tid', ':ticket_id')
+      ->where('alias = :old_alias')
+      ->setParameter(':new_alias', $newAlias)
       ->setParameter(':ticket_id', $ticketId)
-      ->setParameter(':alias', $newAlias)
+      ->setParameter(':old_alias', $oldAlias)
       ->execute();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function removeNamedAliases(array $aliases): int {
+    if (empty($aliases)) {
+      return 0;
+    }
+    $aliases = array_values($aliases);
+    $placeholders = implode(', ', array_map(fn($i) => ':alias_' . $i, array_keys($aliases)));
+    $qb = $this->qb()->delete('aliases')
+      ->where('alias IN (' . $placeholders . ')');
+    foreach ($aliases as $i => $alias) {
+      $qb->setParameter(':alias_' . $i, $alias);
+    }
+    return (int) $qb->execute();
   }
 
   /**

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -45,6 +45,12 @@ interface Repository {
 
   public function removeAlias($ticket_id, $alias);
 
+  public function removeAliasByName(string $alias): int;
+
+  public function findAlias(string $alias): ?object;
+
+  public function updateAlias(string $oldAlias, string $newAlias, $ticketId): void;
+
   public function loadAlias($alias);
 
   public function listAliases($filter = '');

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -47,6 +47,8 @@ interface Repository {
 
   public function removeAliasByName(string $alias): int;
 
+  public function removeNamedAliases(array $aliases): int;
+
   public function findAlias(string $alias): ?object;
 
   public function updateAlias(string $oldAlias, string $newAlias, $ticketId): void;

--- a/tests/Commands/AliasTest.php
+++ b/tests/Commands/AliasTest.php
@@ -38,11 +38,11 @@ class AliasTest extends TlTestBase {
       'alias' => 'pony',
     ]);
     $this->assertMatchesRegularExpression('/Created new alias/', $output->getDisplay());
+    // Delete by alias name (ticket_id arg used as the alias name), confirm yes.
     $output = $this->executeCommand('alias', [
-      'ticket_id' => 1234,
-      'alias' => 'pony',
+      'ticket_id' => 'pony',
       '--delete' => TRUE,
-    ]);
+    ], ['y']);
     $this->assertMatchesRegularExpression('/Removed alias/', $output->getDisplay());
   }
 
@@ -77,6 +77,170 @@ class AliasTest extends TlTestBase {
     foreach ($aliases as $alias) {
       $this->assertMatchesRegularExpression('/' . $alias . '/', $output->getDisplay());
     }
+  }
+
+  /**
+   * @covers ::execute
+   * Tests interactive add loop.
+   */
+  public function testInteractiveAdd() {
+    $this->setupConnector();
+    // Simulate: ticket=1234, alias=myproject, then no to "Add another?"
+    $output = $this->executeCommand('alias', [], [
+      '1234',
+      'myproject',
+      'n',
+    ]);
+    $this->assertMatchesRegularExpression('/Created new alias/', $output->getDisplay());
+    // Verify alias was stored.
+    $existing = $this->getRepository()->findAlias('myproject');
+    $this->assertNotNull($existing);
+    $this->assertEquals(1234, $existing->tid);
+  }
+
+  /**
+   * @covers ::execute
+   * Tests interactive add loop with multiple aliases.
+   */
+  public function testInteractiveAddMultiple() {
+    $this->setupConnector();
+    // First: ticket=1234, alias=proj1, yes to another
+    // Second: ticket=5678, alias=proj2, no to another
+    $output = $this->executeCommand('alias', [], [
+      '1234',
+      'proj1',
+      'y',
+      '5678',
+      'proj2',
+      'n',
+    ]);
+    $display = $output->getDisplay();
+    $this->assertMatchesRegularExpression('/Created new alias/', $display);
+    $this->assertNotNull($this->getRepository()->findAlias('proj1'));
+    $this->assertNotNull($this->getRepository()->findAlias('proj2'));
+  }
+
+  /**
+   * @covers ::execute
+   * Tests duplicate prevention with overwrite prompt — user says yes.
+   */
+  public function testDuplicateAddOverwrite() {
+    $this->setupConnector();
+    // Create original alias.
+    $this->executeCommand('alias', ['ticket_id' => 1234, 'alias' => 'pony']);
+    // Try to add same alias pointing to a different ticket — confirm overwrite.
+    $output = $this->executeCommand('alias', [
+      'ticket_id' => 5678,
+      'alias' => 'pony',
+    ], ['y']);
+    $this->assertMatchesRegularExpression('/Updated alias/', $output->getDisplay());
+    $existing = $this->getRepository()->findAlias('pony');
+    $this->assertEquals(5678, $existing->tid);
+  }
+
+  /**
+   * @covers ::execute
+   * Tests duplicate prevention with overwrite prompt — user says no.
+   */
+  public function testDuplicateAddSkip() {
+    $this->setupConnector();
+    // Create original alias.
+    $this->executeCommand('alias', ['ticket_id' => 1234, 'alias' => 'pony']);
+    // Try to add same alias — decline overwrite.
+    $output = $this->executeCommand('alias', [
+      'ticket_id' => 5678,
+      'alias' => 'pony',
+    ], ['n']);
+    $this->assertMatchesRegularExpression('/Skipped/', $output->getDisplay());
+    // Alias still points to original ticket.
+    $existing = $this->getRepository()->findAlias('pony');
+    $this->assertEquals(1234, $existing->tid);
+  }
+
+  /**
+   * @covers ::execute
+   * Tests deleting a single alias by name.
+   */
+  public function testDeleteByName() {
+    $this->setupConnector();
+    $this->executeCommand('alias', ['ticket_id' => 1234, 'alias' => 'pony']);
+    // alias arg is the first positional; pass as ticket_id since alias is 2nd.
+    // With --delete and only one arg provided, it reads ticket_id as the alias name.
+    $output = $this->executeCommand('alias', [
+      'ticket_id' => 'pony',
+      '--delete' => TRUE,
+    ], ['y']);
+    $this->assertMatchesRegularExpression('/Removed alias/', $output->getDisplay());
+    $this->assertNull($this->getRepository()->findAlias('pony'));
+  }
+
+  /**
+   * @covers ::execute
+   * Tests deleting a single alias by name — user cancels.
+   */
+  public function testDeleteByNameCancelled() {
+    $this->setupConnector();
+    $this->executeCommand('alias', ['ticket_id' => 1234, 'alias' => 'pony']);
+    $output = $this->executeCommand('alias', [
+      'ticket_id' => 'pony',
+      '--delete' => TRUE,
+    ], ['n']);
+    $this->assertMatchesRegularExpression('/Cancelled/', $output->getDisplay());
+    $this->assertNotNull($this->getRepository()->findAlias('pony'));
+  }
+
+  /**
+   * @covers ::execute
+   * Tests editing an alias — rename and re-target.
+   */
+  public function testEdit() {
+    $this->setupConnector();
+    $this->executeCommand('alias', ['ticket_id' => 1234, 'alias' => 'pony']);
+    // Edit: new alias name = "unicorn", new ticket = 5678.
+    $output = $this->executeCommand('alias', [
+      'ticket_id' => 'pony',
+      '--edit' => TRUE,
+    ], ['unicorn', '5678']);
+    $this->assertMatchesRegularExpression('/Updated alias/', $output->getDisplay());
+    $this->assertNull($this->getRepository()->findAlias('pony'));
+    $updated = $this->getRepository()->findAlias('unicorn');
+    $this->assertNotNull($updated);
+    $this->assertEquals(5678, $updated->tid);
+  }
+
+  /**
+   * @covers ::execute
+   * Tests editing an alias — keep same name, change ticket only.
+   */
+  public function testEditTicketOnly() {
+    $this->setupConnector();
+    $this->executeCommand('alias', ['ticket_id' => 1234, 'alias' => 'pony']);
+    // Press Enter to keep alias name, change ticket to 5678.
+    $output = $this->executeCommand('alias', [
+      'ticket_id' => 'pony',
+      '--edit' => TRUE,
+    ], ['', '5678']);
+    $this->assertMatchesRegularExpression('/Updated alias/', $output->getDisplay());
+    $updated = $this->getRepository()->findAlias('pony');
+    $this->assertNotNull($updated);
+    $this->assertEquals(5678, $updated->tid);
+  }
+
+  /**
+   * @covers ::execute
+   * Tests editing with no changes made.
+   */
+  public function testEditNoChanges() {
+    $this->setupConnector();
+    $this->executeCommand('alias', ['ticket_id' => 1234, 'alias' => 'pony']);
+    // Keep both values unchanged.
+    $output = $this->executeCommand('alias', [
+      'ticket_id' => 'pony',
+      '--edit' => TRUE,
+    ], ['', '']);
+    $this->assertMatchesRegularExpression('/No changes made/', $output->getDisplay());
+    $existing = $this->getRepository()->findAlias('pony');
+    $this->assertEquals(1234, $existing->tid);
   }
 
 }

--- a/tests/TlTestBase.php
+++ b/tests/TlTestBase.php
@@ -121,10 +121,13 @@ abstract class TlTestBase extends TestCase {
    * @return \Symfony\Component\Console\Tester\CommandTester
    *   Command tester. Use ::getDisplay() to return the output.
    */
-  protected function executeCommand($name, array $input = []) {
+  protected function executeCommand($name, array $input = [], array $inputs = []) {
     $command = $this->container->get('app.command.' . $name);
     $command->setApplication($this->application);
     $command_tester = new CommandTester($command);
+    if ($inputs) {
+      $command_tester->setInputs($inputs);
+    }
     $command_tester->execute(['command' => $command->getName()] + $input);
     return $command_tester;
   }


### PR DESCRIPTION
- Bulk create aliases (`tl alias` - interactive prompt)
- Bulk delete aliases (`tl alias --delete` - interactive prompt)
- Edit alias support (`tl alias <alias> --edit`)
- Don't require ticket id to delete an alias (`tl alias --delete <alias>`)
- Duplicate alias prevention

Insert vibe code disclaimer here

<details>
<summary>More details below, summarised by the LLM</summary>

## Adding aliases

**Before:** `tl alias <ticket_id> <alias>` — one at a time, all on one line.

**After:** Running `tl alias` with no arguments drops into an interactive loop:

```
Ticket ID: npp-199
Alias: myproject
Created new alias myproject -> npp-199

Add another? (y/N):
```

The one-shot `tl alias <ticket_id> <alias>` syntax still works unchanged.

**Duplicate prevention:** If you try to add an alias that already exists (either interactively or one-shot), you're prompted to overwrite rather than silently creating a duplicate:

```
Alias myproject already points to ticket npp-100. Update to npp-199? (y/N):
```

---

## Deleting aliases

**Before:** `tl alias <ticket_id> <alias> --delete` — had to know both the ticket ID and the alias name, no confirmation.

**After — delete by name:** `tl alias <alias> --delete` — just the alias name, with a confirmation prompt:

```
Delete alias myproject -> npp-199? (y/N):
```

**After — bulk delete:** `tl alias --delete` with no arguments shows a numbered multi-select list, then lists what will be deleted before confirming:

```
Select aliases to delete (comma-separated numbers):
  [0] myproject -> npp-199
  [1] otherproject -> npp-200
  [2] oldthing -> npp-11
> 0,2

The following aliases will be deleted:
  myproject -> npp-199
  oldthing -> npp-11
Delete 2 alias(es)? (y/N):
```

---

## Editing aliases

**New.** `tl alias <alias> --edit` prompts for a new alias name and ticket ID, pre-filled with the current values — press Enter to keep either unchanged:

```
Alias [myproject]: myproj
Ticket ID [npp-199]: npp-250
Updated alias myproj -> npp-250
```

`tl alias --edit` with no arguments shows a picker list first, then the same edit prompts.

</details>